### PR TITLE
2020.3.0 preparation : Changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
-## 2020.2.5 (2020-10-08)
+## 2020.3.0 (2020-10-27)
+  * Rebranding Wayk Den to Wayk Bastion
+  * Upgrade the authentication component
+  * Add a button to reset the white label in the web interface
+  * Fix an issue where machine registration state could be lost after certificate renewal
+  * Fix an issue where a session could not be opened with machine name if it was not lowercase
   * Fix Backup-WaykDenData/Restore-WaykDenData commands on Windows 
   * Fix handling of netstat wrapper when the command is not available
+
+## 2020.2.5 (2020-10-08)
+  * Fix an issue where machine registration state could be lost
 
 ## 2020.2.4 (2020-08-25)
   * Improve "All Servers" section to display machines by group


### PR DESCRIPTION
J'ai remarqué dans ps-gallery qu'il y avait une version 2020.2.6 que tu as fait hier. Tu m'en as glissé un mot, mais pas certain de savoir ce qu'on retrouve à l'intérieur et cette version n'apparait pas dans le changelog. Est-ce qu'on veut l'ajouter ?

Il y avait également une PR ouverte sur WaykDen-ps avec ce changelog : https://github.com/Devolutions/WaykDen-ps/pull/124/files

