### PR TITLE
MongoDB backup/restore fix for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
-## Last changes (unreleased)
+## 2020.3.1 (2020)
   * Change den-lucid log level to warn and log format to json
+  * Fix broken Backup/Restore for MongoDB Windows containers
 
 ## 2020.3.0 (2020-10-27)
   * Rebranding Wayk Den to Wayk Bastion

--- a/WaykBastion/Public/WaykBastionData.ps1
+++ b/WaykBastion/Public/WaykBastionData.ps1
@@ -50,7 +50,9 @@ function Backup-WaykBastionData
     # make sure parent output directory exists
     New-Item -Path $(Split-Path -Path $BackupPath) -ItemType "Directory" -Force | Out-Null
 
-    $CmdArgs = @('docker', 'exec', $ContainerName, 'mongodump', '--gzip', "--archive=${TempBackupPath}")
+    $MongoUrl = "mongodb://${ContainerName}:27017"
+    $CmdArgs = @('docker', 'exec', $ContainerName, 'mongodump', '--gzip', `
+        "--archive=${TempBackupPath}", '--uri', $MongoUrl)
     $cmd = $CmdArgs -Join " "
     Write-Verbose $cmd
     Invoke-Expression $cmd
@@ -112,7 +114,9 @@ function Restore-WaykBastionData
     Write-Verbose $cmd
     Invoke-Expression $cmd
 
-    $CmdArgs = @('docker', 'exec', $ContainerName, 'mongorestore', '--drop', '--gzip', "--archive=${TempBackupPath}")
+    $MongoUrl = "mongodb://${ContainerName}:27017"
+    $CmdArgs = @('docker', 'exec', $ContainerName, 'mongorestore', '--drop', '--gzip', `
+        "--archive=${TempBackupPath}", '--uri', $MongoUrl)
     $cmd = $CmdArgs -Join " "
     Write-Verbose $cmd
     Invoke-Expression $cmd

--- a/WaykBastion/WaykBastion.psd1
+++ b/WaykBastion/WaykBastion.psd1
@@ -7,7 +7,7 @@
     RootModule = 'WaykBastion.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2020.3.0'
+    ModuleVersion = '2020.3.1'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Desktop', 'Core'


### PR DESCRIPTION
For some odd reason connecting to 127.0.0.1 inside the Windows container connects to an empty database, but using the explicit container IP address or name works just fine.