### PR TITLE
Version bump to 2020.3.2 - den-server:2.13.0 + picky:4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
-## 2020.3.1 (2020)
+## 2020.3.2 (2020-11-23)
+  * Improve the interface of Wayk web client
+  * Fix an issue where the server could be unresponsive
+  * Fix potential session connection failure when client and server clocks are not synchronized
+ 
+## 2020.3.1 (2020-10-30)
   * Change den-lucid log level to warn and log format to json
   * Fix broken Backup/Restore for MongoDB Windows containers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
-## 2020.3.2 (2020-11-23)
+## 2020.3.2 (2020-11-26)
   * Improve the interface of Wayk web client
   * Fix an issue where the server could be unresponsive
   * Fix potential session connection failure when client and server clocks are not synchronized

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -13,8 +13,8 @@ function Get-WaykBastionImage
     $Platform = $config.DockerPlatform
 
     $LucidVersion = '3.9.0'
-    $PickyVersion = '4.7.0'
-    $ServerVersion = '2.12.0'
+    $PickyVersion = '4.8.0'
+    $ServerVersion = '2.13.0'
 
     $MongoVersion = '4.2'
     $TraefikVersion = '1.7'

--- a/WaykBastion/WaykBastion.psd1
+++ b/WaykBastion/WaykBastion.psd1
@@ -7,7 +7,7 @@
     RootModule = 'WaykBastion.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2020.3.1'
+    ModuleVersion = '2020.3.2'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Desktop', 'Core'


### PR DESCRIPTION
Préparation version 2020.3.2. **Ne pas merger tout de suite.** 