### PR TITLE
2020.3.4: Update lucid to 3.9.1 (fix refresh token issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
+## 2020.3.4 (2020-01-07)
+  * Fix an issue where user logged in Wayk Client was logged out every day
+
 ## 2020.3.3 (2020-12-03)
   * Fix IIS ARR websocket issue
 

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -12,7 +12,7 @@ function Get-WaykBastionImage
 
     $Platform = $config.DockerPlatform
 
-    $LucidVersion = '3.9.0'
+    $LucidVersion = '3.9.1'
     $PickyVersion = '4.8.0'
     $ServerVersion = '2.13.0'
 
@@ -318,6 +318,7 @@ function Get-WaykBastionService
         "LUCID_LOGIN__PATH_PREFIX" = "lucid";
         "LUCID_LOGIN__PASSWORD_DELEGATION" = "true";
         "LUCID_LOGIN__DEFAULT_LOCALE" = "en_US";
+        "LUCID_LOGIN__SKIP_COMPLETE_PROFILE" = "true";
         "LUCID_LOG__LEVEL" = "warn";
         "LUCID_LOG__FORMAT" = "json";
         "RUST_BACKTRACE" = $RustBacktrace;   

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -14,7 +14,7 @@ function Get-WaykBastionImage
 
     $LucidVersion = '3.9.1'
     $PickyVersion = '4.8.0'
-    $ServerVersion = '2.13.0'
+    $ServerVersion = '2.13.1'
 
     $MongoVersion = '4.2'
     $TraefikVersion = '1.7'

--- a/WaykBastion/WaykBastion.psd1
+++ b/WaykBastion/WaykBastion.psd1
@@ -7,7 +7,7 @@
     RootModule = 'WaykBastion.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2020.3.3'
+    ModuleVersion = '2020.3.4'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Desktop', 'Core'


### PR DESCRIPTION
Ne pas merger tout de suite. Préparation d'une version 2020.3.4 pour corriger le problème avec les refresh token de lucid. Dès que l'image lucid sera disponible, on pourra merger et aller de l'avant pour faire la release.