### PR TITLE
Remove ldap params: LDAP can be configured via the webui 

### DIFF
--- a/WaykBastion/Public/WaykBastionCertificate.ps1
+++ b/WaykBastion/Public/WaykBastionCertificate.ps1
@@ -37,24 +37,3 @@ function Import-WaykBastionCertificate
     Set-Content -Path $TraefikPemFile -Value $CertificateData -Force
     Set-Content -Path $TraeficKeyFile -Value $PrivateKeyData -Force
 }
-
-function Import-WaykLdapCertificate
-{
-    [CmdletBinding()]
-    param(
-        [string] $ConfigPath,
-        [string] $CertificateFile
-    )
-
-    $ConfigPath = Find-WaykBastionConfig -ConfigPath:$ConfigPath
-
-    $config = Get-WaykBastionConfig -ConfigPath:$ConfigPath
-
-    $CertificateData = Get-Content -Path $CertificateFile -Raw -ErrorAction Stop
-
-    $DenServerPath = Join-Path $ConfigPath "den-server"
-    New-Item -Path $DenServerPath -ItemType "Directory" -Force | Out-Null
-
-    $LdapRootCaFile = Join-Path $DenServerPath "ldap-root-ca.pem"
-    Set-Content -Path $LdapRootCaFile -Value $CertificateData -Force
-}

--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -37,17 +37,6 @@ class WaykBastionConfig
     [bool] $JetExternal = $false
     [string] $JetRelayImage
 
-    # LDAP
-    [string] $LdapServerUrl
-    [string] $LdapServerIp
-    [string] $LdapUsername
-    [string] $LdapPassword
-    [string] $LdapUserGroup
-    [string] $LdapServerType
-    [string] $LdapBaseDn
-    [string] $LdapBindType
-    [bool] $LdapCertificateValidation = $false
-
     # Picky
     [string] $PickyUrl
     [bool] $PickyExternal = $false
@@ -472,17 +461,6 @@ function New-WaykBastionConfig
         [bool] $JetExternal,
         [string] $JetRelayImage,
 
-        # LDAP
-        [string] $LdapServerUrl,
-        [string] $LdapServerIp,
-        [string] $LdapUsername,
-        [string] $LdapPassword,
-        [string] $LdapUserGroup,
-        [string] $LdapServerType,
-        [string] $LdapBaseDn,
-        [string] $LdapBindType,
-        [bool] $LdapCertificateValidation,
-
         # Picky
         [string] $PickyUrl,
         [bool] $PickyExternal,
@@ -590,17 +568,6 @@ function Set-WaykBastionConfig
         [int] $JetTcpPort,
         [bool] $JetExternal,
         [string] $JetRelayImage,
-
-        # LDAP
-        [string] $LdapServerUrl,
-        [string] $LdapServerIp,
-        [string] $LdapUsername,
-        [string] $LdapPassword,
-        [string] $LdapUserGroup,
-        [string] $LdapServerType,
-        [string] $LdapBaseDn,
-        [string] $LdapBindType,
-        [bool] $LdapCertificateValidation,
 
         # Picky
         [string] $PickyUrl,

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -381,49 +381,6 @@ function Get-WaykBastionService
         $DenServer.Environment['WIP_EXPERIMENTAL_FEATURES'] = 'true'
     }
 
-    if (![string]::IsNullOrEmpty($config.LdapServerUrl)) {
-        $DenServer.Environment['LDAP_SERVER_URL'] = $config.LdapServerUrl
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapServerIp)) {
-        $DenServer.Environment['LDAP_SERVER_IP'] = $config.LdapServerIp
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapUsername)) {
-        $DenServer.Environment['LDAP_USERNAME'] = $config.LdapUsername
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapPassword)) {
-        $DenServer.Environment['LDAP_PASSWORD'] = $config.LdapPassword
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapUserGroup)) {
-        $DenServer.Environment['LDAP_USER_GROUP'] = $config.LdapUserGroup
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapServerType)) {
-        $DenServer.Environment['LDAP_SERVER_TYPE'] = $config.LdapServerType
-
-        if ($config.LdapCertificateValidation) {
-            $DenServer.Environment['LDAP_CERTIFICATE_VALIDATION'] = 'true'
-        } else {
-            $DenServer.Environment['LDAP_CERTIFICATE_VALIDATION'] = 'false'
-        }
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapBaseDn)) {
-        $DenServer.Environment['LDAP_BASE_DN'] = $config.LdapBaseDn
-    }
-
-    if (![string]::IsNullOrEmpty($config.LdapBindType)) {
-        $DenServer.Environment['LDAP_BIND_TYPE'] = $config.LdapBindType
-    }
-
-    if (Test-Path $(Join-Path $ConfigPath 'den-server/ldap-root-ca.pem')) {
-        $DenServer.Environment['LDAP_TRUSTED_ROOT_CA_FILE'] = `
-            @($DenServerDataPath, "ldap-root-ca.pem") -Join $PathSeparator
-    }
-
     if (![string]::IsNullOrEmpty($config.NatsUrl)) {
         $DenServer.Environment['NATS_HOST'] = $config.NatsUrl
     }

--- a/WaykBastion/WaykBastion.psd1
+++ b/WaykBastion/WaykBastion.psd1
@@ -67,7 +67,7 @@
     FunctionsToExport = @('New-WaykBastionConfig', 'Set-WaykBastionConfig',
         'Get-WaykBastionConfig', 'Clear-WaykBastionConfig', 'Remove-WaykBastionConfig',
         'Get-WaykBastionPath', 'Enter-WaykBastionConfig', 'Exit-WaykBastionConfig',
-        'Import-WaykBastionCertificate', 'Import-WaykLdapCertificate',
+        'Import-WaykBastionCertificate', 
         'Start-WaykBastion', 'Stop-WaykBastion', 'Restart-WaykBastion',
         'Update-WaykBastionImage',
         'Register-WaykBastionService', 'Unregister-WaykBastionService',


### PR DESCRIPTION
I assume that people who had set those parameters, they have started their Bastion at least once. So the ldap info has been pushed in the database. Now, we should always use the info from the database. It can be updated via the web UI.

I think (maybe @awakecoding you can confirm), ldap parameters will stay in the json file but as soon as we update a parameter, they will be removed. It should not create any issue.