### PR TITLE
wayk-2187: Lucid update - Remove default lucid user

### DIFF
--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -45,8 +45,6 @@ class WaykBastionConfig
     # Lucid
     [string] $LucidUrl
     [string] $LucidApiKey
-    [string] $LucidAdminUsername
-    [string] $LucidAdminSecret
     [bool] $LucidExternal = $false
     [string] $LucidImage
 
@@ -161,14 +159,6 @@ function Expand-WaykBastionConfigKeys
 
     if (-Not $config.LucidApiKey) {
         $config.LucidApiKey = New-RandomString -Length 32
-    }
-
-    if (-Not $config.LucidAdminUsername) {
-        $config.LucidAdminUsername = New-RandomString -Length 16
-    }
-
-    if (-Not $config.LucidAdminSecret) {
-        $config.LucidAdminSecret = New-RandomString -Length 10
     }
 }
 
@@ -469,8 +459,6 @@ function New-WaykBastionConfig
         # Lucid
         [string] $LucidUrl,
         [string] $LucidApiKey,
-        [string] $LucidAdminUsername,
-        [string] $LucidAdminSecret,
         [bool] $LucidExternal,
         [string] $LucidImage,
 
@@ -577,8 +565,6 @@ function Set-WaykBastionConfig
         # Lucid
         [string] $LucidUrl,
         [string] $LucidApiKey,
-        [string] $LucidAdminUsername,
-        [string] $LucidAdminSecret,
         [bool] $LucidExternal,
         [string] $LucidImage,
 

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -12,7 +12,7 @@ function Get-WaykBastionImage
 
     $Platform = $config.DockerPlatform
 
-    $LucidVersion = '3.9.3'
+    $LucidVersion = '3.9.4'
     $PickyVersion = '4.8.0'
     $ServerVersion = '3.1.0'
 
@@ -25,7 +25,7 @@ function Get-WaykBastionImage
 
     $images = if ($Platform -ne "windows") {
         [ordered]@{ # Linux containers
-            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-buster";
+            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-buster-dev";
             "den-picky" = "devolutions/picky:${PickyVersion}-buster";
             "den-server" = "devolutions/den-server:${ServerVersion}-buster";
 
@@ -38,7 +38,7 @@ function Get-WaykBastionImage
         }
     } else {
         [ordered]@{ # Windows containers
-            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-servercore-ltsc2019";
+            "den-lucid" = "devolutions/den-lucid:${LucidVersion}-servercore-ltsc2019-dev";
             "den-picky" = "devolutions/picky:${PickyVersion}-servercore-ltsc2019";
             "den-server" = "devolutions/den-server:${ServerVersion}-servercore-ltsc2019";
 
@@ -151,8 +151,6 @@ function Get-WaykBastionService
 
     $DenApiKey = $config.DenApiKey
     $LucidApiKey = $config.LucidApiKey
-    $LucidAdminUsername = $config.LucidAdminUsername
-    $LucidAdminSecret = $config.LucidAdminSecret
 
     $PickyUrl = $config.PickyUrl
     $LucidUrl = $config.LucidUrl
@@ -299,8 +297,7 @@ function Get-WaykBastionService
         $DenLucid.PublishAll = $true
     }
     $DenLucid.Environment = [ordered]@{
-        "LUCID_ADMIN__SECRET" = $LucidAdminSecret;
-        "LUCID_ADMIN__USERNAME" = $LucidAdminUsername;
+        "LUCID_ADMIN__SKIP" = "true";
         "LUCID_API__KEY" = $LucidApiKey;
         "LUCID_DATABASE__URL" = $MongoUrl;
         "LUCID_TOKEN__DEFAULT_ISSUER" = "$ExternalUrl";


### PR DESCRIPTION
Default lucid user has to be removed because now, we keep our user info in lucid and we don't duplicate info in our database.