### PR TITLE
Wayk 2230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
+## 2021.1.3 (unreleased)
+  * Add parameters to set server/lucid log level
+
 ## 2021.1.2 (2021-03-09)
   * Add support for two-factor authentication (2FA)
   * Remove all LDAP parameters from the powershell module. Account provider can be configured via the web interface

--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -12,6 +12,7 @@ class WaykBastionConfig
     [string] $ExternalUrl
     [string] $ListenerUrl
     [string] $ServerMode
+    [string] $ServerLogLevel
     [int] $ServerCount
     [string] $DenServerUrl
     [string] $DenRouterUrl
@@ -48,6 +49,7 @@ class WaykBastionConfig
     [string] $LucidApiKey
     [bool] $LucidExternal = $false
     [string] $LucidImage
+    [string] $LucidLogLevel
 
     # NATS
     [string] $NatsUrl
@@ -210,6 +212,8 @@ function Expand-WaykBastionConfig
     $MongoUrlDefault = "mongodb://den-mongo:27017"
     $MongoVolumeDefault = "den-mongodata"
     $ServerModeDefault = "Private"
+    $ServerLogLevelDefault = "info"
+    $LucidLogLevelDefault = "warn"
     $ListenerUrlDefault = "http://0.0.0.0:4000"
     $JetRelayUrlDefault = "https://api.jet-relay.net"
     $PickyUrlDefault = "http://den-picky:12345"
@@ -243,6 +247,14 @@ function Expand-WaykBastionConfig
 
     if (-Not $config.ServerMode) {
         $config.ServerMode = $ServerModeDefault
+    }
+
+    if (-Not $config.ServerLogLevel) {
+        $config.ServerLogLevel = $ServerLogLevelDefault
+    }
+
+    if (-Not $config.LucidLogLevel) {
+        $config.LucidLogLevel = $LucidLogLevelDefault
     }
 
     if (-Not $config.ServerCount) {
@@ -429,6 +441,8 @@ function New-WaykBastionConfig
         [string] $ExternalUrl,
         [string] $ListenerUrl,
         [string] $ServerMode,
+        [ValidateSet("off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $ServerLogLevel,
         [int] $ServerCount,
         [string] $DenServerUrl,
         [string] $DenRouterUrl,
@@ -465,6 +479,9 @@ function New-WaykBastionConfig
         [string] $LucidApiKey,
         [bool] $LucidExternal,
         [string] $LucidImage,
+        [ValidateSet("off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $LucidLogLevel,
+
 
         # NATS
         [string] $NatsUrl,
@@ -540,6 +557,8 @@ function Set-WaykBastionConfig
         [string] $ExternalUrl,
         [string] $ListenerUrl,
         [string] $ServerMode,
+        [ValidateSet("off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $ServerLogLevel,
         [int] $ServerCount,
         [string] $DenServerUrl,
         [string] $DenRouterUrl,
@@ -576,6 +595,9 @@ function Set-WaykBastionConfig
         [string] $LucidApiKey,
         [bool] $LucidExternal,
         [string] $LucidImage,
+        [ValidateSet("off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $LucidLogLevel,
+
 
         # NATS
         [string] $NatsUrl,

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -156,6 +156,9 @@ function Get-WaykBastionService
     $LucidUrl = $config.LucidUrl
     $DenServerUrl = $config.DenServerUrl
 
+    $ServerLogLevel = $config.ServerLogLevel
+    $LucidLogLevel = $config.LucidLogLevel
+
     $RustBacktrace = "1"
 
     if ($Platform -eq "linux") {
@@ -316,7 +319,7 @@ function Get-WaykBastionService
         "LUCID_LOGIN__PASSWORD_DELEGATION" = "true";
         "LUCID_LOGIN__DEFAULT_LOCALE" = "en_US";
         "LUCID_LOGIN__SKIP_COMPLETE_PROFILE" = "true";
-        "LUCID_LOG__LEVEL" = "warn";
+        "LUCID_LOG__LEVEL" = $LucidLogLevel;
         "LUCID_LOG__FORMAT" = "json";
         "RUST_BACKTRACE" = $RustBacktrace;   
     }
@@ -360,7 +363,7 @@ function Get-WaykBastionService
         "RUST_BACKTRACE" = $RustBacktrace;
     }
     $DenServer.Volumes = @("$ConfigPath/den-server:$DenServerDataPath`:ro")
-    $DenServer.Command = "-l info"
+    $DenServer.Command = "-l $ServerLogLevel"
     $DenServer.Healthcheck = [DockerHealthcheck]::new("curl -sS $DenServerUrl/health")
 
     if ($config.ServerMode -eq 'Private') {

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -668,12 +668,25 @@ function Start-WaykBastion
     [CmdletBinding()]
     param(
         [string] $ConfigPath,
-        [switch] $SkipPull
+        [switch] $SkipPull,
+        [ValidateSet("", "off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $ServerLogLevel,
+        [ValidateSet("", "off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $LucidLogLevel
     )
 
     $ConfigPath = Find-WaykBastionConfig -ConfigPath:$ConfigPath
     $config = Get-WaykBastionConfig -ConfigPath:$ConfigPath
     Expand-WaykBastionConfig -Config $config
+
+    if ($ServerLogLevel) {
+        $config.ServerLogLevel = $ServerLogLevel
+    }
+
+    if ($LucidLogLevel) {
+        $config.LucidLogLevel = $LucidLogLevel
+    }
+
     Test-WaykBastionConfig -Config:$config
 
     Test-DockerHost
@@ -744,12 +757,16 @@ function Restart-WaykBastion
 {
     [CmdletBinding()]
     param(
-        [string] $ConfigPath
+        [string] $ConfigPath,
+        [ValidateSet("off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $ServerLogLevel,
+        [ValidateSet("off","error", "warn", "info", "debug", "trace", IgnoreCase = $false)]
+        [string] $LucidLogLevel
     )
 
     $ConfigPath = Find-WaykBastionConfig -ConfigPath:$ConfigPath
     Stop-WaykBastion -ConfigPath:$ConfigPath
-    Start-WaykBastion -ConfigPath:$ConfigPath
+    Start-WaykBastion -ConfigPath:$ConfigPath -ServerLogLevel:$ServerLogLevel -LucidLogLevel:$LucidLogLevel
 }
 
 function Get-WaykBastionServiceDefinition()


### PR DESCRIPTION
I added 2 parameters in the config : ServerLogLevel and LucidLogLevel. If they are not set, default are info for den-server and warn for lucid (it was already those defaults)

I also added a way to set the log level when we start if you want to set the log level only for one execution. For example, you could have : 

Start-WaykBastion -ServerLogLevel debug -LucidLogLevel trace
Restart-WaykBastion -ServerLogLevel info -LucidLogLevel debug