### PR TITLE
WAYK-2418: Add command 'Export-WaykBastionLogs' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This document provides a list of notable changes introduced in Wayk Bastion by release.
 
 ## 2021.1.3 (unreleased)
+  * New command `Export-WaykBastionLogs` to generate a zip file with all logs
   * Add parameters to set server/lucid log level
 
 ## 2021.1.2 (2021-03-09)

--- a/WaykBastion/Private/DockerHelper.ps1
+++ b/WaykBastion/Private/DockerHelper.ps1
@@ -144,6 +144,31 @@ function Get-ContainerIsHealthy
     return $healthy -Match 'healthy'
 }
 
+function Export-ContainerLogs
+{
+    param(
+        [string] $Name,
+        [string] $FilePath
+    )
+
+    $CmdArgs = @('docker', 'logs', $Name, '>', $FilePath)
+    $cmd = $CmdArgs -Join " "
+    Write-Verbose $cmd
+    Invoke-Expression $cmd
+}
+
+function Export-ContainersState
+{
+    param(
+        [string] $FilePath
+    )
+
+    $CmdArgs = @('docker', 'ps', '-a', '>', $FilePath)
+    $cmd = $CmdArgs -Join " "
+    Write-Verbose $cmd
+    Invoke-Expression $cmd
+}
+
 function Wait-ContainerHealthy
 {
     param(

--- a/WaykBastion/Private/DockerHelper.ps1
+++ b/WaykBastion/Private/DockerHelper.ps1
@@ -151,10 +151,7 @@ function Export-ContainerLogs
         [string] $FilePath
     )
 
-    $CmdArgs = @('docker', 'logs', $Name, '>', $FilePath)
-    $cmd = $CmdArgs -Join " "
-    Write-Verbose $cmd
-    Invoke-Expression $cmd
+    & 'docker' 'logs' $Name 2>&1 > $FilePath
 }
 
 function Export-ContainersState
@@ -163,10 +160,7 @@ function Export-ContainersState
         [string] $FilePath
     )
 
-    $CmdArgs = @('docker', 'ps', '-a', '>', $FilePath)
-    $cmd = $CmdArgs -Join " "
-    Write-Verbose $cmd
-    Invoke-Expression $cmd
+    & 'docker' 'ps' '-a' > $FilePath
 }
 
 function Wait-ContainerHealthy

--- a/WaykBastion/Public/WaykBastionLogs.ps1
+++ b/WaykBastion/Public/WaykBastionLogs.ps1
@@ -1,0 +1,59 @@
+. "$PSScriptRoot/../Private/PlatformHelper.ps1"
+
+function Export-WaykBastionLogs
+{
+    [CmdletBinding()]
+    param(
+        [string] $ConfigPath,
+        [string] $LogPath
+    )
+
+    # Get services to know which containers exist
+    $ConfigPath = Find-WaykBastionConfig -ConfigPath:$ConfigPath
+    $config = Get-WaykBastionConfig -ConfigPath:$ConfigPath
+    Expand-WaykBastionConfig -Config $config
+    $Services = Get-WaykBastionService -ConfigPath:$ConfigPath -Config $config
+    
+    # Get temp folder to generate logs
+    if (Get-IsWindows) {
+        $TempPath = "C:\Windows\temp"
+    } else {
+        $TempPath = "/tmp"
+    }
+
+    # Build the zip file path
+    if (-Not $LogPath) {
+        $LogPath = Get-Location
+    }
+    $LogPath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($LogPath)
+
+    if (-Not ($LogPath -match ".zip")) {
+        $LogFileName = "WaykBastion-" + (Get-Date -Format "yyyyMMdd_HHmmss") + ".zip"
+        $LogFilePath = Join-Path $LogPath $LogFileName
+    } else {
+        $LogFilePath = $LogPath
+    }
+
+    # Generate containers state
+    $TempFilePath = Join-Path $TempPath "docker_ps.log"
+    Export-ContainersState -FilePath $TempFilePath
+    $FilesToZip = @($TempFilePath)
+
+    # Generate container log
+    foreach ($Service in $Services) {
+        if (Get-ContainerExists -Name $Service.ContainerName) {
+            $FileName = $Service.ContainerName + ".log"
+            $TempFilePath = Join-Path $TempPath $FileName
+            Export-ContainerLogs -Name $Service.ContainerName -FilePath $TempFilePath
+            $FilesToZip += $TempFilePath
+        }
+    }
+
+    # Generate zip file
+    Compress-Archive -Path $FilesToZip -CompressionLevel "Optimal" -DestinationPath $LogFilePath
+
+    # Clean temp folder
+    foreach ($File in $FilesToZip) {
+        Remove-Item $File
+    }   
+}

--- a/WaykBastion/WaykBastion.psd1
+++ b/WaykBastion/WaykBastion.psd1
@@ -71,7 +71,8 @@
         'Start-WaykBastion', 'Stop-WaykBastion', 'Restart-WaykBastion',
         'Update-WaykBastionImage',
         'Register-WaykBastionService', 'Unregister-WaykBastionService',
-        'Backup-WaykBastionData', 'Restore-WaykBastionData')
+        'Backup-WaykBastionData', 'Restore-WaykBastionData',
+        'Export-WaykBastionLogs')
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = @()


### PR DESCRIPTION
The command `Export-WaykBastionLogs` generate a zip file. It contains : 

- The result of `docker ps -a`
- The result of `docker logs xyz` of all services

You can specify the output file like this : `Export-WaykBastionLogs -LogPath ./log.zip`

You can run the command with -Verbose to see all commands that is run.
PS /home/fdubois/MyNewDen> Export-WaykBastionLogs -Verbose
VERBOSE: docker ps -a > /tmp/docker_ps.log
VERBOSE: docker logs den-mongo > /tmp/den-mongo.log
VERBOSE: docker logs den-picky > /tmp/den-picky.log
VERBOSE: docker logs den-lucid > /tmp/den-lucid.log
VERBOSE: docker logs den-server > /tmp/den-server.log
VERBOSE: docker logs den-traefik > /tmp/den-traefik.log