### PR TITLE
wayk-1971: Add parameter 'DisableCors'

### DIFF
--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -18,6 +18,7 @@ class WaykBastionConfig
     [string] $DenRouterUrl
     [int] $DenKeepAliveInterval
     [string] $DenApiKey
+    [bool] $DisableCors = $false
     [bool] $DisableTelemetry = $false
     [bool] $ExperimentalFeatures = $false
     [bool] $ServerExternal = $false
@@ -328,6 +329,10 @@ function Test-WaykBastionConfig
             Write-Warning "HTTPS is not configured for external access, peer-to-peer sessions will be disabled"
         }
     }
+
+    if ($config.DisableCors) {
+        Write-Warning "Disabling CORS could be a security issue. It should be disabled only for development purposes"
+    }
 }
 
 function Export-TraefikToml()
@@ -448,6 +453,7 @@ function New-WaykBastionConfig
         [string] $DenRouterUrl,
         [int] $DenKeepAliveInterval,
         [string] $DenApiKey,
+        [bool] $DisableCors,
         [bool] $DisableTelemetry,
         [bool] $ExperimentalFeatures,
         [bool] $ServerExternal,
@@ -564,6 +570,7 @@ function Set-WaykBastionConfig
         [string] $DenRouterUrl,
         [int] $DenKeepAliveInterval,
         [string] $DenApiKey,
+        [bool] $DisableCors,
         [bool] $DisableTelemetry,
         [bool] $ExperimentalFeatures,
         [bool] $ServerExternal,

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -377,6 +377,10 @@ function Get-WaykBastionService
         $DenServer.Environment['DEN_ROUTER_KEEP_ALIVE_INTERVAL'] = $config.DenKeepAliveInterval
     }
 
+    if ($config.DisableCors) {
+        $DenServer.Environment['DEN_DISABLE_CORS'] = 'true'
+    }
+
     if ($config.DisableTelemetry) {
         $DenServer.Environment['DEN_DISABLE_TELEMETRY'] = 'true'
     }


### PR DESCRIPTION
On devrait désactiver les cors uniquement en développement. Si un client doit désactiver ça, il faudrait investiguer pourquoi. C'est la raison pour laquelle j'ai ajouté un warning au démarrage si on désactive les CORS, afin que le client sache que ce n'est pas une bonne idée.