### PR TITLE
wayk-2418: Add WaykBastion configuration to exported logs

### DIFF
--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -307,6 +307,35 @@ function Expand-WaykBastionConfig
     Expand-WaykBastionConfigImage -Config:$Config
 }
 
+function Remove-WaykBastionConfigSensitiveData
+{
+    param(
+        [WaykBastionConfig] $Config
+    )
+
+    $HiddenValue = "***Hidden value***"
+
+    if ($config.DenApiKey) {
+        $config.DenApiKey = $HiddenValue
+    }
+
+    if ($config.LucidApiKey) {
+        $config.LucidApiKey = $HiddenValue
+    }
+
+    if ($config.NatsUsername) {
+        $config.NatsUsername = $HiddenValue
+    }
+
+    if ($config.NatsPassword) {
+        $config.NatsPassword = $HiddenValue
+    }
+
+    if ($config.RedisPassword) {
+        $config.RedisPassword = $HiddenValue
+    }
+}
+
 function Test-WaykBastionConfig
 {
     param(
@@ -729,7 +758,8 @@ function Get-WaykBastionConfig
     param(
         [string] $ConfigPath,
         [switch] $Expand,
-        [switch] $NonDefault
+        [switch] $NonDefault,
+        [switch] $RemoveSensitiveData
     )
 
     $ConfigPath = Find-WaykBastionConfig -ConfigPath:$ConfigPath
@@ -790,6 +820,10 @@ function Get-WaykBastionConfig
     if ($NonDefault) {
         # remove default properties from object
         $config = Remove-DefaultProperties $config $([WaykBastionConfig]::new())
+    }
+
+    if ($RemoveSensitiveData) {
+        Remove-WaykBastionConfigSensitiveData $config
     }
 
     return $config

--- a/WaykBastion/Public/WaykBastionLogs.ps1
+++ b/WaykBastion/Public/WaykBastionLogs.ps1
@@ -31,6 +31,11 @@ function Export-WaykBastionLogs
         $LogFilePath = $LogPath
     }
 
+    # Save server configuration
+    $TempFilePath = Join-Path $TempPath "WaykBastion.cfg"
+    Remove-WaykBastionConfigSensitiveData $config
+    $config | Out-File $TempFilePath
+    
     # Generate containers state
     $TempFilePath = Join-Path $TempPath "docker_ps.log"
     Export-ContainersState -FilePath $TempFilePath


### PR DESCRIPTION
I removed den api key, lucid api key, nats username/password and redis password from the configuration. I set these fields to "***Hidden value***" so we will at least know that a value was configured on their side.

Here is an example for my config : 

```
DisableCors               : False
DisableDbSchemaValidation : True
DisableTelemetry          : True
ExperimentalFeatures      : True
ServerExternal            : False
MongoExternal             : False
TraefikExternal           : False
JetExternal               : True
PickyExternal             : False
LucidExternal             : False
NatsExternal              : False
RedisExternal             : False
Realm                     : fdubois.ngrok.io
ExternalUrl               : https://fdubois.ngrok.io
ListenerUrl               : http://0.0.0.0:4000
ServerMode                : Private
ServerLogLevel            : info
ServerCount               : 1
DenServerUrl              : http://192.168.1.126:10255
DenRouterUrl              : http://192.168.1.126:4491
DenKeepAliveInterval      : 0
DenApiKey                 : ***Hidden value***
ServerImage               : devolutions/den-server:3.3.0-buster
MongoUrl                  : mongodb://192.168.1.126:27017
MongoVolume               : den-mongodata
MongoImage                : library/mongo:4.2-bionic
TraefikImage              : library/traefik:1.7
JetRelayUrl               : https://api.jet-relay.net
JetTcpPort                : 0
JetRelayImage             : 
PickyUrl                  : http://192.168.1.126:12345
PickyImage                : devolutions/picky:4.8.0-buster
LucidUrl                  : http://192.168.1.126:4242
LucidApiKey               : ***Hidden value***
LucidImage                : devolutions/den-lucid:3.9.4-buster
LucidLogLevel             : warn
NatsUrl                   : 
NatsUsername              : 
NatsPassword              : 
NatsImage                 : 
RedisUrl                  : 
RedisPassword             : 
RedisImage                : library/redis:5.0-buster
DockerNetwork             : none
DockerPlatform            : linux
DockerIsolation           : 
DockerRestartPolicy       : on-failure
DockerHost                : 192.168.1.126
SyslogServer              : 
`