### PR TITLE
Use the externalUrl as jet url if the jet is not external

### DIFF
--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -296,9 +296,8 @@ function Expand-WaykBastionConfig
             $config.JetRelayUrl = $JetRelayUrlDefault
         }
     } else {
-        if (-Not $config.JetRelayUrl) {
-            $config.JetRelayUrl = $config.ExternalUrl
-        }
+        $config.JetRelayUrl = $config.ExternalUrl
+        
         if (-Not $config.JetTcpPort) {
             $config.JetTcpPort = 8080
         }


### PR DESCRIPTION
Si le JET est configuré pour ne pas être "external" (donc internal), on devrait toujours utiliser l'external URL et ce, même si un jetUrl est spécifié.  Comme ça, on peut mettre JetExternal à false tout en laissant une configuration sur un JetUrl.  Plus simple lorsqu'on veut passer d'un à l'autre, sinon, on doit toujours retirer le JetUrl pour ne pas qu'il soit utilisé. Make sense ?