### PR TITLE
Add support for nanoserver container images

### DIFF
--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -72,6 +72,7 @@ class WaykBastionConfig
     [string] $DockerIsolation
     [string] $DockerRestartPolicy
     [string] $DockerHost
+    [string] $DockerBaseImage
     [string] $SyslogServer
 }
 
@@ -603,6 +604,7 @@ function New-WaykBastionConfig
         [ValidateSet("no","on-failure","always","unless-stopped")]
         [string] $DockerRestartPolicy,
         [string] $DockerHost,
+        [string] $DockerBaseImage,
         [string] $SyslogServer,
 
         [switch] $Force
@@ -721,6 +723,7 @@ function Set-WaykBastionConfig
         [ValidateSet("no","on-failure","always","unless-stopped")]
         [string] $DockerRestartPolicy,
         [string] $DockerHost,
+        [string] $DockerBaseImage,
         [string] $SyslogServer,
 
         [switch] $Force

--- a/WaykBastion/WaykBastion.psd1
+++ b/WaykBastion/WaykBastion.psd1
@@ -69,7 +69,7 @@
         'Get-WaykBastionPath', 'Enter-WaykBastionConfig', 'Exit-WaykBastionConfig',
         'Import-WaykBastionCertificate', 
         'Start-WaykBastion', 'Stop-WaykBastion', 'Restart-WaykBastion',
-        'Update-WaykBastionImage',
+        'Get-WaykBastionImage', 'Update-WaykBastionImage',
         'Register-WaykBastionService', 'Unregister-WaykBastionService',
         'Backup-WaykBastionData', 'Restore-WaykBastionData',
         'Export-WaykBastionLogs')

--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,10 @@ New-Item -Path "$PSScriptRoot\package\$module" -ItemType 'Directory' -Force | Ou
     New-Item -Path "$PSScriptRoot\package\$module\$_" -ItemType 'Directory' -Force | Out-Null
 }
 
+& dotnet nuget add source "https://api.nuget.org/v3/index.json" -n "nuget.org" | Out-Null
+
 & dotnet publish "$PSScriptRoot\$module\src" -f netstandard2.0 -c Release -o "$PSScriptRoot\$module\bin"
+
 Expand-Archive -Path .\resources\cmdlet-service.zip -DestinationPath "$PSScriptRoot\$module\bin" -Force
 Copy-Item "$PSScriptRoot\$module\bin" -Destination "$PSScriptRoot\package\$module" -Recurse -Force
 


### PR DESCRIPTION
Expose Get-WaykBastionImage, add "DockerBaseImage" filter to select "nanoserver", optimize Update-WaykBastionImage to only pull images that are going to be used, modify Get-WaykBastionImage to optionally return all container images, or just the ones required. It works just fine on my Windows 10 laptop with nanoserver containers + an external MongoDB. If MongoDB is not set to external, it just uses the heavyweight servercore base image.