### PR TITLE
Migrate to traefik 2.4

### DIFF
--- a/WaykBastion/Private/TraefikHelper.ps1
+++ b/WaykBastion/Private/TraefikHelper.ps1
@@ -155,6 +155,7 @@ function New-TraefikConfig
         $traefik.http.routers.Add("gateway", [ordered]@{
                     "rule"        = "PathPrefix(``/jet``)";
                     "service"     = "gateway";
+                    "tls"         = @{};
                 })
         $traefik.http.services.Add("gateway", [ordered]@{
                     "loadBalancer" = [ordered]@{

--- a/WaykBastion/Private/TraefikHelper.ps1
+++ b/WaykBastion/Private/TraefikHelper.ps1
@@ -1,5 +1,5 @@
 
-function New-TraefikToml
+function New-TraefikConfig
 {
     [OutputType('System.String')]
     param(
@@ -9,7 +9,8 @@ function New-TraefikToml
         [string] $PickyUrl,
         [string] $DenRouterUrl,
         [string] $DenServerUrl,
-        [bool] $JetExternal
+        [bool] $JetExternal,
+        [string] $GatewayUrl
     )
 
     $url = [System.Uri]::new($ListenerUrl)
@@ -27,7 +28,6 @@ function New-TraefikToml
     # note: .pem file should contain leaf cert + intermediate CA cert, in that order.
 
     $TraefikPort = $Port
-    $TraefikEntrypoint = $Protocol
     $TraefikCertFile = $(@($TraefikDataPath, "den-server.pem") -Join $PathSeparator)
     $TraefikKeyFile = $(@($TraefikDataPath, "den-server.key") -Join $PathSeparator)
 
@@ -35,122 +35,135 @@ function New-TraefikToml
     $TraefikCertFile = $TraefikCertFile -replace '\\', '\\'
     $TraefikKeyFile = $TraefikKeyFile -replace '\\', '\\'
 
-    $templates = @()
-
-    $templates += '
-logLevel = "INFO"
-
-[file]
-
-[entryPoints]
-    [entryPoints.${TraefikEntrypoint}]
-    address = ":${TraefikPort}"'
+    $traefik = [ordered]@{
+        "log"         = [ordered]@{
+            "level" = "WARN";
+        }
+        "providers"   = [ordered]@{
+            "file" = [ordered]@{
+                "watch"     = $true;
+                "directory" = ".";
+            }
+        }
+        "entryPoints" = [ordered]@{
+            "web" = [ordered]@{
+                "address" = "`:$TraefikPort";
+            }
+        }
+        "http"        = [ordered]@{
+            "routers"     = [ordered]@{
+                "lucid"      = [ordered]@{
+                    "rule"        = "PathPrefix(``/lucid``)";
+                    "service"     = "lucid";
+                    "middlewares" = @("lucid");
+                    "tls"         = @{};
+                }
+                "picky"      = [ordered]@{
+                    "rule"        = "PathPrefix(``/picky``)";
+                    "service"     = "picky";
+                    "middlewares" = @("picky");
+                    "tls"         = @{};
+                }
+                "den-router" = [ordered]@{
+                    "rule"        = "PathPrefix(``/cow``)";
+                    "service"     = "den-router";
+                    "middlewares" = @("den-router");
+                    "tls"         = @{};
+                }
+                "den-server" = [ordered]@{
+                    "rule"        = "PathPrefix(``/``)";
+                    "service"     = "den-server";
+                    "middlewares" = @("web-redirect");
+                    "tls"         = @{};
+                }
+            }
+            "middlewares" = [ordered]@{
+                "lucid"        = [ordered]@{
+                    "stripPrefix" = [ordered]@{
+                        "prefixes" = @("/lucid")
+                    }
+                }
+                "picky"        = [ordered]@{
+                    "stripPrefix" = [ordered]@{
+                        "prefixes" = @("/picky")
+                    }
+                }
+                "den-router"   = [ordered]@{
+                    "stripPrefix" = [ordered]@{
+                        "prefixes" = @("/cow")
+                    }
+                }
+                "web-redirect" = [ordered]@{
+                    "redirectRegex" = [ordered]@{
+                        "regex"       = "^http(s)?://([^/]+)/?$";
+                        "replacement" = "http`$1://`$2/web";
+                    }
+                }
+            }
+            "services"    = [ordered]@{
+                "lucid"      = [ordered]@{
+                    "loadBalancer" = [ordered]@{
+                        "passHostHeader" = $true;
+                        "servers"        = @(
+                            @{"url" = $LucidUrl }
+                        )
+                    }
+                }
+                "picky"      = [ordered]@{
+                    "loadBalancer" = [ordered]@{
+                        "passHostHeader" = $true;
+                        "servers"        = @(
+                            @{"url" = $PickyUrl }
+                        )
+                    }
+                }
+                "den-router" = [ordered]@{
+                    "loadBalancer" = [ordered]@{
+                        "passHostHeader" = $true;
+                        "servers"        = @(
+                            @{"url" = $DenRouterUrl }
+                        )
+                    }
+                }
+                "den-server" = [ordered]@{
+                    "loadBalancer" = [ordered]@{
+                        "passHostHeader" = $true;
+                        "servers"        = @(
+                            @{"url" = $DenServerUrl }
+                        )
+                    }
+                }
+            }
+        }
+    }
 
     if ($Protocol -eq 'https') {
-        $templates += '
-        [entryPoints.${TraefikEntrypoint}.tls]
-            [entryPoints.${TraefikEntrypoint}.tls.defaultCertificate]
-            certFile = "${TraefikCertFile}"
-            keyFile = "${TraefikKeyFile}"'
+        $traefik.Add("tls", [ordered]@{
+                "stores" = [ordered]@{
+                    "default" = [ordered]@{
+                        "defaultCertificate" = [ordered]@{
+                            "certFile" = $TraefikCertFile;
+                            "keyFile"  = $TraefikKeyFile;
+                        }
+                    }
+                }
+            })
     }
-
-    $templates += '
-        [entryPoints.${TraefikEntrypoint}.redirect]
-        regex = "^http(s)?://([^/]+)/?`$"
-        replacement = "http`$1://`$2/web"
-    '
-
-    $templates += '
-[frontends]
-    [frontends.lucid]
-    passHostHeader = true
-    backend = "lucid"
-    entrypoints = ["${TraefikEntrypoint}"]
-        [frontends.lucid.routes.lucid]
-        rule = "PathPrefixStrip:/lucid"
-
-    [frontends.lucidop]
-    passHostHeader = true
-    backend = "lucid"
-    entrypoints = ["${TraefikEntrypoint}"]
-        [frontends.lucidop.routes.lucidop]
-        rule = "PathPrefix:/op"
-
-    [frontends.lucidauth]
-    passHostHeader = true
-    backend = "lucid"
-    entrypoints = ["${TraefikEntrypoint}"]
-        [frontends.lucidauth.routes.lucidauth]
-        rule = "PathPrefix:/auth"
-
-    [frontends.picky]
-    passHostHeader = true
-    backend = "picky"
-    entrypoints = ["${TraefikEntrypoint}"]
-        [frontends.picky.routes.picky]
-        rule = "PathPrefixStrip:/picky"
-
-    [frontends.router]
-    passHostHeader = true
-    backend = "router"
-    entrypoints = ["${TraefikEntrypoint}"]
-        [frontends.router.routes.router]
-        rule = "PathPrefixStrip:/cow"
-
-    [frontends.server]
-    passHostHeader = true
-    backend = "server"
-    entrypoints = ["${TraefikEntrypoint}"]
-'
 
     if (-Not $JetExternal) {
-        $templates += '
-    [frontends.gateway]
-    passHostHeader = true
-    backend = "gateway"
-    entrypoints = ["${TraefikEntrypoint}"]
-        [frontends.gateway.routes.gateway]
-        rule = "PathPrefix:/jet"
-'
+        $traefik.http.routers.Add("gateway", [ordered]@{
+                    "rule"        = "PathPrefix(``/jet``)";
+                    "service"     = "gateway";
+                })
+        $traefik.http.services.Add("gateway", [ordered]@{
+                    "loadBalancer" = [ordered]@{
+                        "passHostHeader" = $true;
+                        "servers"        = @(
+                            @{"url" = $GatewayUrl }
+                        )
+                    }
+                })
     }
 
-    $templates += '
-[backends]
-    [backends.lucid]
-        [backends.lucid.servers.lucid]
-        url = "${LucidUrl}"
-        weight = 10
-
-    [backends.picky]
-        [backends.picky.servers.picky]
-        url = "${PickyUrl}"
-        method="drr"
-        weight = 10
-
-    [backends.router]
-        [backends.router.servers.router]
-        url = "${DenRouterUrl}"
-        method="drr"
-        weight = 10
-
-    [backends.server]
-        [backends.server.servers.server]
-        url = "${DenServerUrl}"
-        weight = 10
-        method="drr"
-'
-
-    if (-Not $JetExternal) {
-            $templates += '
-    [backends.gateway]
-        [backends.gateway.servers.gateway]
-        url = "http://den-gateway:7171"
-        weight = 10
-        method="drr"
-'
-    }
-
-    $template = -Join $templates
-
-    return Invoke-Expression "@`"`r`n$template`r`n`"@"
+    $traefik | ConvertTo-Yaml
 }

--- a/WaykBastion/Private/TraefikHelper.ps1
+++ b/WaykBastion/Private/TraefikHelper.ps1
@@ -28,6 +28,7 @@ function New-TraefikConfig
     # note: .pem file should contain leaf cert + intermediate CA cert, in that order.
 
     $TraefikPort = $Port
+    $TraefikYamlFile = $(@($TraefikDataPath, "traefik.yaml") -Join $PathSeparator)
     $TraefikCertFile = $(@($TraefikDataPath, "den-server.pem") -Join $PathSeparator)
     $TraefikKeyFile = $(@($TraefikDataPath, "den-server.key") -Join $PathSeparator)
 
@@ -42,7 +43,7 @@ function New-TraefikConfig
         "providers"   = [ordered]@{
             "file" = [ordered]@{
                 "watch"     = $true;
-                "directory" = ".";
+                "filename" = $TraefikYamlFile;
             }
         }
         "entryPoints" = [ordered]@{

--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -369,7 +369,7 @@ function Test-WaykBastionConfig
     }
 }
 
-function Export-TraefikToml()
+function Export-TraefikConfig()
 {
     param(
         [string] $ConfigPath
@@ -383,17 +383,18 @@ function Export-TraefikToml()
     $TraefikPath = Join-Path $ConfigPath "traefik"
     New-Item -Path $TraefikPath -ItemType "Directory" -Force | Out-Null
 
-    $TraefikTomlFile = Join-Path $TraefikPath "traefik.toml"
+    $TraefikYamlFile = Join-Path $TraefikPath "traefik.yaml"
 
-    $TraefikToml = New-TraefikToml -Platform $config.DockerPlatform `
+    $TraefikYaml = New-TraefikConfig -Platform $config.DockerPlatform `
         -ListenerUrl $config.ListenerUrl `
         -LucidUrl $config.LucidUrl `
         -PickyUrl $config.PickyUrl `
         -DenRouterUrl $config.DenRouterUrl `
         -DenServerUrl $config.DenServerUrl `
-        -JetExternal $config.JetExternal
+        -JetExternal $config.JetExternal `
+        -GatewayUrl "http://den-gateway:7171"
 
-    Set-Content -Path $TraefikTomlFile -Value $TraefikToml
+    Set-Content -Path $TraefikYamlFile -Value $TraefikYaml
 }
 
 function Export-PickyConfig()
@@ -643,7 +644,7 @@ function New-WaykBastionConfig
 
     Save-WaykBastionConfig -ConfigPath:$ConfigPath -Config:$Config -ConfigFormat $WaykBastionConfigFormat -ErrorAction 'Stop'
 
-    Export-TraefikToml -ConfigPath:$ConfigPath
+    Export-TraefikConfig -ConfigPath:$ConfigPath
 }
 
 function Set-WaykBastionConfig
@@ -750,7 +751,7 @@ function Set-WaykBastionConfig
 
     Save-WaykBastionConfig -ConfigPath:$ConfigPath -Config:$Config -ConfigFormat $WaykBastionConfigFormat -ErrorAction 'Stop'
 
-    Export-TraefikToml -ConfigPath:$ConfigPath
+    Export-TraefikConfig -ConfigPath:$ConfigPath
 }
 
 function Get-WaykBastionConfig

--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -37,6 +37,7 @@ class WaykBastionConfig
 
     # Jet
     [string] $JetRelayUrl
+    [string] $JetInternalUrl
     [int] $JetTcpPort
     [bool] $JetExternal = $false
     [string] $JetRelayImage
@@ -218,11 +219,12 @@ function Expand-WaykBastionConfig
     $ServerLogLevelDefault = "info"
     $LucidLogLevelDefault = "warn"
     $ListenerUrlDefault = "http://0.0.0.0:4000"
-    $JetRelayUrlDefault = "https://api.jet-relay.net"
     $PickyUrlDefault = "http://den-picky:12345"
     $LucidUrlDefault = "http://den-lucid:4242"
     $DenServerUrlDefault = "http://den-server:10255"
     $DenRouterUrlDefault = "http://den-server:4491"
+    $JetRelayUrlDefault = "https://api.jet-relay.net"
+    $JetInternalUrlDefault = "http://den-gateway:7171"
 
     if (-Not $config.DockerNetwork) {
         $config.DockerNetwork = $DockerNetworkDefault
@@ -234,6 +236,7 @@ function Expand-WaykBastionConfig
         $LucidUrlDefault = $LucidUrlDefault -Replace "den-lucid", $config.DockerHost
         $DenServerUrlDefault = $DenServerUrlDefault -Replace "den-server", $config.DockerHost
         $DenRouterUrlDefault = $DenRouterUrlDefault -Replace "den-server", $config.DockerHost
+        $JetInternalUrlDefault = $JetInternalUrlDefault -Replace "den-gateway", $config.DockerHost
     }
 
     if (-Not $config.DockerPlatform) {
@@ -290,6 +293,10 @@ function Expand-WaykBastionConfig
 
     if (-Not $config.DenRouterUrl) {
         $config.DenRouterUrl = $DenRouterUrlDefault
+    }
+
+    if (-Not $config.JetInternalUrl) {
+        $config.JetInternalUrl = $JetInternalUrlDefault
     }
 
     if ($config.JetExternal) {
@@ -392,7 +399,7 @@ function Export-TraefikConfig()
         -DenRouterUrl $config.DenRouterUrl `
         -DenServerUrl $config.DenServerUrl `
         -JetExternal $config.JetExternal `
-        -GatewayUrl "http://den-gateway:7171"
+        -GatewayUrl $config.JetInternalUrl
 
     Set-Content -Path $TraefikYamlFile -Value $TraefikYaml
 }
@@ -565,6 +572,7 @@ function New-WaykBastionConfig
 
         # Jet
         [string] $JetRelayUrl,
+        [string] $JetInternalUrl,
         [int] $JetTcpPort,
         [bool] $JetExternal,
         [string] $JetRelayImage,
@@ -684,6 +692,7 @@ function Set-WaykBastionConfig
 
         # Jet
         [string] $JetRelayUrl,
+        [string] $JetInternalUrl,
         [int] $JetTcpPort,
         [bool] $JetExternal,
         [string] $JetRelayImage,

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -492,6 +492,8 @@ function Get-WaykBastionService
         $DenTraefik.Networks += $DenNetwork
     }
     $DenTraefik.PublishAll = $true
+    $TraefikConfigFile = @($TraefikDataPath, "traefik.yaml") -Join $PathSeparator
+    $DenTraefik.Command = "--configfile `"$TraefikConfigFile`""
     $DenTraefik.Volumes = @("$ConfigPath/traefik:$TraefikDataPath")
     $DenTraefik.External = $config.TraefikExternal
     $Services += $DenTraefik
@@ -515,6 +517,7 @@ function Get-WaykBastionService
         if ($DenNetwork -NotMatch "none") {
             $DenGateway.Networks += $DenNetwork
         } else {
+            $DenGateway.TargetPorts += 7171
             $DenGateway.PublishAll = $true
         }
 

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -79,6 +79,7 @@ function Get-WaykBastionImage
         @('den-lucid','den-picky','den-server','den-gateway') | ForEach-Object {
             $images[$_] = $images[$_] -Replace "servercore-ltsc2019", "nanoserver-1809"
         }
+        $images['den-mongo'] = "library/mongo:${MongoVersion}-nanoserver-1809";
         $images['den-traefik'] = "library/traefik:${TraefikVersion}-nanoserver";
         $images['den-nats'] = "library/nats:${NatsVersion}-nanoserver";
     }
@@ -491,11 +492,6 @@ function Get-WaykBastionService
         $DenTraefik.Networks += $DenNetwork
     }
     $DenTraefik.PublishAll = $true
-    $TraefikConfigFile = @($TraefikDataPath, "traefik.yaml") -Join $PathSeparator
-    $DenTraefik.Environment = [ordered]@{
-        "TRAEFIK_LOG_LEVEL" = "WARN";
-        "TRAEFIK_PROVIDERS_FILE_FILENAME" = $TraefikConfigFile;
-    }
     $DenTraefik.Volumes = @("$ConfigPath/traefik:$TraefikDataPath")
     $DenTraefik.External = $config.TraefikExternal
     $Services += $DenTraefik

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -41,7 +41,7 @@ function Get-WaykBastionImage
     $ServerVersion = '3.6.0'
 
     $MongoVersion = '4.2'
-    $TraefikVersion = '1.7'
+    $TraefikVersion = '2.4'
     $NatsVersion = '2.1'
     $RedisVersion = '5.0'
 
@@ -491,8 +491,12 @@ function Get-WaykBastionService
         $DenTraefik.Networks += $DenNetwork
     }
     $DenTraefik.PublishAll = $true
+    $TraefikConfigFile = @($TraefikDataPath, "traefik.yaml") -Join $PathSeparator
+    $DenTraefik.Environment = [ordered]@{
+        "TRAEFIK_LOG_LEVEL" = "WARN";
+        "TRAEFIK_PROVIDERS_FILE_FILENAME" = $TraefikConfigFile;
+    }
     $DenTraefik.Volumes = @("$ConfigPath/traefik:$TraefikDataPath")
-    $DenTraefik.Command = ("--file --configFile=" + $(@($TraefikDataPath, "traefik.toml") -Join $PathSeparator))
     $DenTraefik.External = $config.TraefikExternal
     $Services += $DenTraefik
 
@@ -725,7 +729,7 @@ function Start-WaykBastion
     $Platform = $config.DockerPlatform
     $Services = Get-WaykBastionService -ConfigPath:$ConfigPath -Config $config
 
-    Export-TraefikToml -ConfigPath:$ConfigPath
+    Export-TraefikConfig -ConfigPath:$ConfigPath
     Export-PickyConfig -ConfigPath:$ConfigPath
     Export-GatewayConfig -ConfigPath:$ConfigPath
 

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -79,7 +79,7 @@ function Get-WaykBastionImage
         @('den-lucid','den-picky','den-server','den-gateway') | ForEach-Object {
             $images[$_] = $images[$_] -Replace "servercore-ltsc2019", "nanoserver-1809"
         }
-        $images['den-mongo'] = "library/mongo:${MongoVersion}-nanoserver-1809";
+        #$images['den-mongo'] = "library/mongo:${MongoVersion}-nanoserver-1809";
         #$images['den-traefik'] = "library/traefik:${TraefikVersion}-nanoserver";
         $images['den-nats'] = "library/nats:${NatsVersion}-nanoserver";
     }

--- a/WaykBastion/Public/WaykBastionService.ps1
+++ b/WaykBastion/Public/WaykBastionService.ps1
@@ -80,7 +80,7 @@ function Get-WaykBastionImage
             $images[$_] = $images[$_] -Replace "servercore-ltsc2019", "nanoserver-1809"
         }
         $images['den-mongo'] = "library/mongo:${MongoVersion}-nanoserver-1809";
-        $images['den-traefik'] = "library/traefik:${TraefikVersion}-nanoserver";
+        #$images['den-traefik'] = "library/traefik:${TraefikVersion}-nanoserver";
         $images['den-nats'] = "library/nats:${NatsVersion}-nanoserver";
     }
 


### PR DESCRIPTION
Migrate to traefik 2.4 from traefik 1.7. The configuration model has changed, and I've used the opportunity to switch to YAML instead of TOML, such that I can use powershell-yaml instead of a half-baked template to generate the toml file. Everything works on both Windows and Linux, the only annoying thing is that traefik 2.x enforces a separation between a static and dynamic configuration file, and the static file need to refer to the dynamic file by path. It's possible to have both within the same file by loading the configuration file and telling that the "dynamic configuration" is basically the current file using its path. I[ asked a few questions about this](https://community.traefik.io/t/unable-to-launch-traefik-with-file-provider-without-repeating-full-path-inside-configuration-file), but since we already use full paths for the TLS certificates, it's not much of an issue.