### PR TITLE
Fix traefik 2.x configuration generation

### DIFF
--- a/WaykBastion/Private/TraefikHelper.ps1
+++ b/WaykBastion/Private/TraefikHelper.ps1
@@ -5,6 +5,7 @@ function New-TraefikConfig
     param(
         [string] $Platform,
         [string] $ListenerUrl,
+        [string] $ExternalUrl,
         [string] $LucidUrl,
         [string] $PickyUrl,
         [string] $DenRouterUrl,
@@ -12,6 +13,9 @@ function New-TraefikConfig
         [bool] $JetExternal,
         [string] $GatewayUrl
     )
+
+    $url = [System.Uri]::new($ExternalUrl)
+    $ExternalScheme = $url.Scheme
 
     $url = [System.Uri]::new($ListenerUrl)
     $Port = $url.Port
@@ -93,7 +97,7 @@ function New-TraefikConfig
                 "web-redirect" = [ordered]@{
                     "redirectRegex" = [ordered]@{
                         "regex"       = "^http(s)?://([^/]+)/?$";
-                        "replacement" = "http`$1://`$2/web";
+                        "replacement" = "${ExternalScheme}`://`$2/web";
                     }
                 }
             }

--- a/WaykBastion/Public/WaykBastionConfig.ps1
+++ b/WaykBastion/Public/WaykBastionConfig.ps1
@@ -394,6 +394,7 @@ function Export-TraefikConfig()
 
     $TraefikYaml = New-TraefikConfig -Platform $config.DockerPlatform `
         -ListenerUrl $config.ListenerUrl `
+        -ExternalUrl $config.ExternalUrl `
         -LucidUrl $config.LucidUrl `
         -PickyUrl $config.PickyUrl `
         -DenRouterUrl $config.DenRouterUrl `


### PR DESCRIPTION
- fix https/http configuration
- use external URL scheme for / to /web redirection

With an external URL set to https and a listener URL set to http, we will need to use http://localhost:4000/web to avoid a redirection to https until we handle the redirections correctly in den-server instead.